### PR TITLE
Added timer to exercises page, don't display inactive challenges

### DIFF
--- a/browser/js/arena/arena.js
+++ b/browser/js/arena/arena.js
@@ -4,9 +4,6 @@ app.config(function($stateProvider) {
     resolve: {
       checkAuthorizedUser : function(AuthService, $state, $stateParams) {
         return AuthService.getLoggedInUser().then(function(user) {
-          console.log(user.isAuthorized === $stateParams.roomKey); //should be false;
-          console.log(user.isAuthorized);
-          console.log($stateParams.roomKey);
           if (!user) {
             alert('You need to log in to participate in a challenge.');
             $state.go('home');

--- a/browser/js/common/directives/rooms/room.html
+++ b/browser/js/common/directives/rooms/room.html
@@ -1,4 +1,4 @@
-<h5> Room Exercise: {{ room.exerciseName }} </h5>
+<h5> Room Exercise: {{ room.exerciseName }}  {{room.timeUntilClose | date:'mm:ss'}}</h5>
 <h5>   
 	Room User(s): {{ room.users[0].username}}
     <a href="/arena/{{ room.roomId }}" ng-click="joinRoom(room.roomId)">Join Room</a>

--- a/browser/js/common/factories/RoomFactory.js
+++ b/browser/js/common/factories/RoomFactory.js
@@ -36,6 +36,11 @@ app.factory('RoomFactory', function($firebaseObject, $q) {
     }; // closes createRoom function
     //very similar ( or same function?) for createPractice
 
+    factory.deleteActiveRoom = function(roomKey) {
+        var ref = new Firebase('http://dazzling-torch-169.firebaseio.com/rooms/' + roomKey);
+        ref.remove();
+    }
+
     factory.updateActiveRoomData = function () {
         return $q(function(resolve, reject) {
             var activeRoomData = [];
@@ -44,7 +49,9 @@ app.factory('RoomFactory', function($firebaseObject, $q) {
                 for (var key in firebaseSnapshot.val()){
                     var roomData = firebaseSnapshot.val()[key];
                     roomData.roomId = key;
-                    activeRoomData.push(roomData);
+                    if (roomData.gameStartTime > Date.now() ) 
+                    // don't put closed rooms (timed out) on scope for now
+                        activeRoomData.push(roomData);
                 };
                 resolve(activeRoomData);
             });

--- a/browser/js/exercises/exercises.html
+++ b/browser/js/exercises/exercises.html
@@ -11,7 +11,6 @@
 <div class="container pt">
     <h2> Active Rooms </h2>
     <room ng-repeat="room in activeRoomData"></room>
-    <waiting-room></waiting-room>
     </div>
 </div>
 </div>

--- a/browser/js/exercises/exercises.js
+++ b/browser/js/exercises/exercises.js
@@ -10,6 +10,7 @@ app.config(function($stateProvider){
 
 
 app.controller('exercisesCtrl', function($scope, $state, RoomFactory, TestFactory, AuthService){
+	$scope.activeRoomData = [ ];
 	TestFactory.getExercises().then(function (exercises){
 		$scope.exercises = exercises;
 	});
@@ -20,7 +21,6 @@ app.controller('exercisesCtrl', function($scope, $state, RoomFactory, TestFactor
 
 	RoomFactory.updateActiveRoomData().then(function (activeRooms){
 		$scope.activeRoomData = activeRooms;
-		console.log($scope.activeRoomData);
 	});
 
 	$scope.joinRoom = function (roomId) {
@@ -34,7 +34,20 @@ app.controller('exercisesCtrl', function($scope, $state, RoomFactory, TestFactor
 		 $scope.roomKey = RoomFactory.createRoom(exercise, $scope.user);
 		 AuthService.getLoggedInUser().then(function(user) {
 		 	user.isAuthorized = $scope.roomKey;
-		 	console.log('iosdhfiqohrqihqio user authorized', user);
 		 });
 	};
+
+	function countDown() {
+		$scope.activeRoomData.forEach(function (room,index) {
+			room.timeUntilClose = Math.max(0, room.gameStartTime - Date.now());
+	  		if (room.gameStartTime <= Date.now() ) {
+	   	 		$scope.activeRoomData.splice(index,1);
+	  		}
+	  		$scope.$digest();
+	  		
+		})
+	}
+
+	var timeout = setInterval(countDown, 1000);
+
 });


### PR DESCRIPTION
@michaelbbae or @iloughman please check this out
Did the following with @lindakung and @iloughman:
- Added timer with amount of time before challenge closes to exercises page
- Only add active challenges (start time of challenge is greater than the current time) to the scope so only those display on the exercises page
- Remove challenges from active challenge list/scope when the timer reaches zero.

Potential next steps: 
- "expired" challenges are still in Firebase because they should only be deleted when the challenge ends (we have not decided when that is/what that means yet)
- would be interesting to have challenges with users in them (but not open for joining) on the exercises page so users can observe the challenge without participating
